### PR TITLE
Use HTTPS when downloading CEF binary

### DIFF
--- a/scripts/core_common/modules/cef.py
+++ b/scripts/core_common/modules/cef.py
@@ -19,7 +19,7 @@ def make():
     if not config.check_option("platform", platform):
       continue
 
-    url = "http://d2ettrnqo7v976.cloudfront.net/cef/"
+    url = "https://d2ettrnqo7v976.cloudfront.net/cef/"
     archive_name = "./cef_binary.7z"
 
     if (-1 != platform.find("_xp")):


### PR DESCRIPTION
Use HTTPS for securely downloading CEF binary.

I think the checksum should also be checked. But it is not obvious to me where the checksum files are. So this PR only covers HTTPS.

See also https://github.com/ONLYOFFICE/DesktopEditors/issues/1664#issuecomment-2322901101